### PR TITLE
fix: prevent ValueError in CopyBlend when pool size < num_objects

### DIFF
--- a/engine/data/dataloader.py
+++ b/engine/data/dataloader.py
@@ -237,7 +237,7 @@ class BatchImageCollateFunction(BaseCollateFunction):
                 if self.random_num_objects:
                     num_objects = random.randint(1, min(self.num_objects, len(objects_pool['boxes'])))
                 else:
-                    num_objects = self.num_objects
+                    num_objects = min(self.num_objects, len(objects_pool['boxes']))
                 
                 # randomly select objects to blend
                 selected_indices = random.sample(range(len(objects_pool['boxes'])), num_objects)


### PR DESCRIPTION
## Summary

Fix `ValueError` in CopyBlend augmentation when object pool size is smaller than `num_objects`.

## Problem

CopyBlend crashes with `ValueError: Sample larger than population` when trying to sample more objects than available in the filtered object pool in [engine/data/dataloader.py:243](https://github.com/Intellindust-AI-Lab/DEIMv2/blob/2817999a4ad598412bdc5afa0f8d32b4e315c3ad/engine/data/dataloader.py#L243).

```python
# randomly select objects to blend
selected_indices = random.sample(range(len(objects_pool['boxes'])), num_objects)
```

This can happen when there are fewer valid objects in the batch than the configured num_objects parameter, typically due to small objects being filtered out by the area threshold and/or small batch sizes.

Closes #12