### PR TITLE
Fix UnboundLocalError in RepNCSPELAN4 when csp_type != 'csp2'

### DIFF
--- a/engine/deim/hybrid_encoder.py
+++ b/engine/deim/hybrid_encoder.py
@@ -200,9 +200,11 @@ class RepNCSPELAN4(nn.Module):
         self.c = c3//2
         self.cv1 = ConvNormLayer_fuse(c1, c3, 1, 1, bias=bias, act=act)
         if csp_type == 'csp2':
-            CSPLayer = CSPLayer2
-        self.cv2 = nn.Sequential(CSPLayer(c3//2, c4, n, 1, bias=bias, act=act, bottletype=VGGBlock), ConvNormLayer_fuse(c4, c4, 3, 1, bias=bias, act=act))
-        self.cv3 = nn.Sequential(CSPLayer(c4, c4, n, 1, bias=bias, act=act, bottletype=VGGBlock), ConvNormLayer_fuse(c4, c4, 3, 1, bias=bias, act=act))
+            CSPLayerType = CSPLayer2
+        else:
+            CSPLayerType = CSPLayer
+        self.cv2 = nn.Sequential(CSPLayerType(c3//2, c4, n, 1, bias=bias, act=act, bottletype=VGGBlock), ConvNormLayer_fuse(c4, c4, 3, 1, bias=bias, act=act))
+        self.cv3 = nn.Sequential(CSPLayerType(c4, c4, n, 1, bias=bias, act=act, bottletype=VGGBlock), ConvNormLayer_fuse(c4, c4, 3, 1, bias=bias, act=act))
         self.cv4 = ConvNormLayer_fuse(c3+(2*c4), c2, 1, 1, bias=bias, act=act)
 
     def forward_chunk(self, x):


### PR DESCRIPTION
## Description

Fix for `UnboundLocalError` in the `RepNCSPELAN4` class that occurs when `csp_type` parameter is set to any value other than `'csp2'`.

## Problem

The current implementation in `hybrid_encoder.py` has a conditional assignment issue:

```python
if csp_type == 'csp2':
    CSPLayer = CSPLayer2
self.cv2 = nn.Sequential(CSPLayer(...), ...)  # CSPLayer used here
```

When `csp_type != 'csp2'`, the local variable `CSPLayer` is never assigned, but Python still treats it as a local variable due to the assignment in the `if` block. This prevents falling back to the global `CSPLayer` class and raises: