### PR TITLE
Fixed transforms that did not work with new versions of PyTorch.

### DIFF
--- a/engine/data/transforms/_transforms.py
+++ b/engine/data/transforms/_transforms.py
@@ -54,8 +54,9 @@ class PadToSize(T.Pad):
         Mask,
         BoundingBoxes,
     )
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
-        sp = F.get_spatial_size(flat_inputs[0])
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+        get_size_func = F.get_size if hasattr(F, "get_size") else F.get_spatial_size
+        sp = get_size_func(flat_inputs[0])
         h, w = self.size[1] - sp[0], self.size[0] - sp[1]
         self.padding = [0, 0, w, h]
         return dict(padding=self.padding)
@@ -66,7 +67,7 @@ class PadToSize(T.Pad):
         self.size = size
         super().__init__(0, fill, padding_mode)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         fill = self._fill[type(inpt)]
         padding = params['padding']
         return F.pad(inpt, padding=padding, fill=fill, padding_mode=self.padding_mode)  # type: ignore[arg-type]
@@ -101,7 +102,7 @@ class ConvertBoxes(T.Transform):
         self.fmt = fmt
         self.normalize = normalize
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         spatial_size = getattr(inpt, _boxes_keys[1])
         if self.fmt:
             in_fmt = inpt.format.value.lower()
@@ -124,7 +125,7 @@ class ConvertPILImage(T.Transform):
         self.dtype = dtype
         self.scale = scale
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         inpt = F.pil_to_tensor(inpt)
         if self.dtype == 'float32':
             inpt = inpt.float()


### PR DESCRIPTION
The current version considers a problem for running train process at new gpus (sm_120). 
The problem lays in discrepancies of torchvision's transforms. 
So the PR considers fix for transforms adapting it for newer versions.
Tested with torch==2.10.0 and torchvision==0.25.0